### PR TITLE
Enhanced CPU load calculations

### DIFF
--- a/logenv.c
+++ b/logenv.c
@@ -578,8 +578,9 @@ int main(int argc, char **argv) {
              */
             if(USAGE_ENABLE != 0) {
 
-                float r = 0;;
-                int tck = sysconf(_SC_CLK_TCK);
+                float r = 0;
+		float s = 0;
+		float sum = 0;
 
                 if((cpu_use = fopen(cpuusage, "r")) == NULL) {
                     printf("\nERROR: Cannot open %s\n", cpuusage);
@@ -608,8 +609,13 @@ int main(int argc, char **argv) {
                     u[8][c] = strtol(&us[8][c], &endptr, 10);
                     u[9][c] = strtol(&us[9][c], &endptr, 10);
 
+		    s = u[0][c] + u[1][c] + u[2][c] + u[3][c] + u[4][c] \
+			+ u[5][c] + u[6][c] + u[7][c] + u[8][c] + u[9][c]; 
+		    sum = use[0][c] + use[1][c] + use[2][c] + use[3][c] + use[4][c] \
+			  + use[5][c] + use[6][c] + use[7][c] + use[8][c] + use[9][c]; 
+
                     r = u[3][c] - use[3][c];
-	                r /= INTERACTIVE_ENABLE * tck;
+		    	r /= (s-sum);
 	                r = 1 - r;
                     r = r < 0 ? 0 : r * 100;  /* filter out any negative numbers */
 


### PR DESCRIPTION
Addressing points risen in #1.
An interesting side effect is that in single-shot mode, as well as the first result in continuous mode, the CPU load values are returned as well - however those are mean values over the entire uptime of a machine.

```
[mctom@Tomusiomat logenv]$ ./logenv -u
0,36.88,38.84,38.39,36.23,34.07
[mctom@Tomusiomat logenv]$ ./logenv -u
0,36.88,38.83,38.38,36.23,34.06
[mctom@Tomusiomat logenv]$ ./logenv -u -s 1
0,36.88,38.83,38.38,36.23,34.06
1,83.63,79.59,83.67,78.35,92.93
2,30.83,42.57,36.36,22.00,21.21
3,35.59,24.24,43.00,57.00,17.17
^C
[mctom@Tomusiomat logenv]$ ./logenv -u -s 5
0,36.88,38.84,38.38,36.24,34.06
5,29.18,31.86,21.17,35.74,27.57
10,28.94,24.60,33.87,22.54,34.34
15,29.40,32.34,25.60,31.45,28.46
^C
```