### PR TITLE
Add RAM usage function

### DIFF
--- a/logenv.c
+++ b/logenv.c
@@ -996,10 +996,11 @@ int main(int argc, char **argv) {
 		while(feof(mem_load) == 0) {
 		    fscanf(mem_load, "%29s %f %*s", field, &nd);
 		    if (strcmp(mem_total  , field) == 0) mt = nd;
-		    if (strcmp(mem_free   , field) == 0) r -= nd;
-		    //if (strcmp(mem_buffers, field) == 0) r -= nd;
-		    if (strcmp(mem_cached , field) == 0) r -= nd;
-		    if (strcmp(mem_srec   , field) == 0) r -= nd;
+		    if (strcmp(mem_avail  , field) == 0) r -= nd;
+//		    if (strcmp(mem_free   , field) == 0) r -= nd;
+//		    if (strcmp(mem_buffers, field) == 0) r -= nd;
+//		    if (strcmp(mem_cached , field) == 0) r -= nd;
+//		    if (strcmp(mem_srec   , field) == 0) r -= nd;
 		}
 		r /= mt;
 		r += 1;

--- a/logenv.c
+++ b/logenv.c
@@ -109,6 +109,9 @@ int main(int argc, char **argv) {
             USAGE_ENABLE = atoi(&line[2])+1;
             OPTIONS_COUNT++;
         }
+        if(!strcmp(argv[i], "-m") || !strcmp(argv[i], "--memory")) {
+            MEM_ENABLE = 1;
+        }
         if(!strcmp(argv[i], "-i") || !strcmp(argv[i], "--milliseconds")) {
             INTERACTIVE_ENABLE = atoi(argv[i+1]);
             COUNT_ENABLE = 1;
@@ -977,6 +980,80 @@ int main(int argc, char **argv) {
                 fclose(cpu_use);
             }
             /*
+	     * Read memory usage
+	     */
+	    if(MEM_ENABLE == 1) {
+
+                float mt;
+		float r = 0;
+		float nd;
+		char field[30];
+
+                if((mem_load = fopen(memload, "r")) == NULL) {
+                    printf("\nERROR: Cannot open %s\n", memload);
+                    exit(1);
+                }
+		while(feof(mem_load) == 0) {
+		    fscanf(mem_load, "%29s %f %*s", field, &nd);
+		    if (strcmp(mem_total  , field) == 0) mt = nd;
+		    if (strcmp(mem_free   , field) == 0) r -= nd;
+		    //if (strcmp(mem_buffers, field) == 0) r -= nd;
+		    if (strcmp(mem_cached , field) == 0) r -= nd;
+		    if (strcmp(mem_srec   , field) == 0) r -= nd;
+		}
+		r /= mt;
+		r += 1;
+		r *= 100;
+                if(QUIET_ENABLE == 0 && RAW_ENABLE == 1) {
+                    printf(",%.3g", r);
+                }
+                if(QUIET_ENABLE == 0 && RAW_ENABLE == 0 && VERBOSE_ENABLE == 1) {
+                    printf("\n\n RAM load = %.3g%%", r);
+                }
+                if(QUIET_ENABLE == 0 && RAW_ENABLE == 0 && COUNT_ENABLE == 1 && VERBOSE_ENABLE == 0) {
+                        printf(",%.3g%%", r);
+                }
+                if(QUIET_ENABLE == 0 && RAW_ENABLE == 0 && COUNT_ENABLE == 0 && VERBOSE_ENABLE == 0) {
+                    if(OPTIONS_COUNT > 1) {
+                        printf("%.3g%%,", r);
+                    }
+                    else {
+                        printf("%.3g%%", r);
+                    }
+                }
+                if(LOG_ENABLE == 1 && RAW_ENABLE == 1) {
+                    fprintf(log_file,",%.3g", r);
+                }
+                if(LOG_ENABLE == 1 && RAW_ENABLE == 0) {
+                    fprintf(log_file,",%.3g%%", r);
+                }
+                if(UDP_ENABLE == 1 && RAW_ENABLE == 1 && COUNT_ENABLE == 1) {
+                    udp_count += sprintf(udp_tx_data + udp_count,",%.3g", r);
+                }
+                if(UDP_ENABLE == 1 && RAW_ENABLE == 1 && COUNT_ENABLE == 0) {
+                    if(OPTIONS_COUNT > 1) {
+                        udp_count += sprintf(udp_tx_data + udp_count,"%.3g,", r);
+                    }
+                    else {
+                        udp_count += sprintf(udp_tx_data + udp_count,"%.3g", r);
+                    }
+                }
+                if(UDP_ENABLE == 1 && RAW_ENABLE == 0 && COUNT_ENABLE == 1) {
+                    udp_count += sprintf(udp_tx_data + udp_count,",%.3g%%", r);
+                }
+                if(UDP_ENABLE == 1 && RAW_ENABLE == 0 && COUNT_ENABLE == 0) {
+                   if(OPTIONS_COUNT > 1) {
+                        udp_count += sprintf(udp_tx_data + udp_count,"%.3g%%,", r);
+                    }
+                    else {
+                        udp_count += sprintf(udp_tx_data + udp_count,"%.3g%%", r);
+                    }
+                }
+            OPTIONS_COUNT--;
+            fclose(mem_load);		
+
+	    }
+            /*
              * eol for stdout and log file
              */
             if(QUIET_ENABLE == 0) {
@@ -1352,6 +1429,7 @@ void usage (void) {
         printf("      --smartpower3-ch2 <tty>\n");
         printf("      --smartpower2 <tty>     Volt, Amp, Watt (HK SmartPower2 microUSB port), default /dev/ttyUSB0\n");
         printf(" -u,  --usage                 CPU core usage, aggregate and core 0 to core n-1\n");
+        printf(" -m,  --memory                Physical memory usage (total - available, see man free)\n");
         printf(" -d,  --date                  Date and Time stamp\n");
         printf(" -r,  --raw                   Raw output, no formatting of freq. or temp.  e.g. 35000 instead of 35\n");
         printf(" -v,  --verbose               Readable dashboard output\n"); 

--- a/logenv.h
+++ b/logenv.h
@@ -57,6 +57,7 @@ char *cpufreq2 = "/cpufreq/scaling_cur_freq";
 char *memload = "/proc/meminfo";
 char *mem_total = "MemTotal:";
 char *mem_free = "MemFree:";
+char *mem_avail = "MemAvailable:";
 char *mem_buffers = "Buffers:";
 char *mem_cached = "Cached:";
 char *mem_srec = "SReclaimable:";

--- a/logenv.h
+++ b/logenv.h
@@ -27,7 +27,7 @@ static void sig_handler(int);
 
 static volatile sig_atomic_t go = 1;
 
-FILE *cpu_online, *cpu_freq, *cpu_thermal, *thermal_type, *cpu_use, *log_file, *gnuplot_file;
+FILE *cpu_online, *cpu_freq, *cpu_thermal, *thermal_type, *cpu_use, *mem_load, *log_file, *gnuplot_file;
 
 time_t now;
 struct tm *t;
@@ -54,6 +54,13 @@ char cpufreq[255];
 char *cpufreq1 = "/sys/devices/system/cpu/cpu";
 char *cpufreq2 = "/cpufreq/scaling_cur_freq";
 
+char *memload = "/proc/meminfo";
+char *mem_total = "MemTotal:";
+char *mem_free = "MemFree:";
+char *mem_buffers = "Buffers:";
+char *mem_cached = "Cached:";
+char *mem_srec = "SReclaimable:";
+
 char thermalzone[255];
 char *thermalzone1 = "/sys/devices/virtual/thermal/thermal_zone";
 char *thermalzone2 = "/temp";
@@ -77,6 +84,7 @@ char four2one[] = "4,1";
 static int SP_ENABLE = 0;
 static int SENSOR_ENABLE = 0;
 static int FREQ_ENABLE = 0;
+static int MEM_ENABLE = 0;
 static int THERMAL_ENABLE = 0;
 static int QUIET_ENABLE = 0;
 static int VERBOSE_ENABLE = 0;


### PR DESCRIPTION
I had a few hours to spare, so I delivered RAM usage option (-m).

The results are calculated differently than in PiStackMon. In fact I cannot recreate my line of thought that led me to that solution.

The results are in line with the output of `free`.

```
[mctom@Tomusiomat logenv]$ make && ./logenv -m && free -v
gcc    -c -o logenv.o logenv.c
gcc -Wall -o logenv bme280/bme280-i2c.o bme280/bme280.o bme280/bmp180.o logenv.o -lm
31.7%
               razem       użyte       wolne    dzielone   buf/cache    dostępne
Pamięć:        31940       10122       10893         925       12308       21817
Wymiana:        4095           0        4095
Zajęta:        20066       14184        5881
[mctom@Tomusiomat logenv]$ qalc "1-(21817/31940)"
1 − (21817 / 31940) ≈ 0,3169380088
```